### PR TITLE
Always check cfg.cli & team name to pilot Args

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,18 +211,15 @@ function uploadBetaTestIPA(_skip){
         console.log("\n");
 
         var cleanArgs = [];
-        
+
         if(cfg.cli == "appc"){
             cleanArgs.push('ti');
-            cleanArgs.push('clean');
-            cleanArgs.push('-p');
-            cleanArgs.push('ios');
-
-        }else{
-            cleanArgs.push('clean');
-            cleanArgs.push('-p');
-            cleanArgs.push('ios');
         }
+        
+        cleanArgs.push('clean');
+        cleanArgs.push('-p');
+        cleanArgs.push('ios');
+        
 
         exec(cfg.cli, cleanArgs, null, function(e){
             console.log(chalk.cyan('Starting Appcelerator App Store Build'));
@@ -236,27 +233,10 @@ function uploadBetaTestIPA(_skip){
                 fs.unlinkSync("./dist/" + tiapp.name + ".ipa");
             }
             
-            var buildArgs = [];
-
-            if(cfg.cli == "appc"){
-                buildArgs.push('run');
-                buildArgs.push('-p');
-                buildArgs.push('ios');
-                buildArgs.push('-T');
-                buildArgs.push('dist-adhoc');
-                buildArgs.push('-O');
-                buildArgs.push('./dist');
-            }else{
-                buildArgs.push('build');
-                buildArgs.push('-p');
-                buildArgs.push('ios');
-                buildArgs.push('-T');
-                buildArgs.push('dist-adhoc');
-                buildArgs.push('-O');
-                buildArgs.push('./dist');
-            }
+            var buildArgs = [cfg.cli == "appc"?'run':'build'];
+            var buildArgsDetail = '-p ios -T dist-adhoc -O ./dist';
+            buildArgs = buildArgs.concat(buildArgsDetail.split(' '));
             
-
             exec(cfg.cli, buildArgs, null, function(e){
                 _pilot();
             });
@@ -567,15 +547,11 @@ exports.send = function(opts){
 
             if(cfg.cli == "appc"){
                 cleanArgs.push('ti');
-                cleanArgs.push('clean');
-                cleanArgs.push('-p');
-                cleanArgs.push('ios');
-
-            }else{
-                cleanArgs.push('clean');
-                cleanArgs.push('-p');
-                cleanArgs.push('ios');
             }
+            
+            cleanArgs.push('clean');
+            cleanArgs.push('-p');
+            cleanArgs.push('ios');
 
             exec(cfg.cli, cleanArgs, null, function(e){
                 console.log(chalk.cyan('Starting Appcelerator App Store Build'));
@@ -586,26 +562,9 @@ exports.send = function(opts){
                     fs.unlinkSync("./dist/" + tiapp.name + ".ipa");
                 }
 
-                var buildArgs = [];
-
-                if(cfg.cli == "appc"){
-                    buildArgs.push('run');
-                    buildArgs.push('-p');
-                    buildArgs.push('ios');
-                    buildArgs.push('-T');
-                    buildArgs.push('dist-adhoc');
-                    buildArgs.push('-O');
-                    buildArgs.push('./dist');
-
-                }else{
-                    buildArgs.push('build');
-                    buildArgs.push('-p');
-                    buildArgs.push('ios');
-                    buildArgs.push('-T');
-                    buildArgs.push('dist-adhoc');
-                    buildArgs.push('-O');
-                    buildArgs.push('./dist');
-                }
+                var buildArgs = [cfg.cli == "appc"?'run':'build'];
+                var buildArgsDetail = '-p ios -T dist-adhoc -O ./dist';
+                buildArgs = buildArgs.concat(buildArgsDetail.split(' '));
 
                 exec(cfg.cli, buildArgs, null, function(e){
                     _deliver();
@@ -1059,33 +1018,19 @@ exports.playsend = function(opts){
 
             if(cfg.cli == "appc"){
                 cleanArgs.push('ti');
-                cleanArgs.push('clean');
-                cleanArgs.push('-p');
-                cleanArgs.push('android');
-
-            }else{
-                cleanArgs.push('clean');
-                cleanArgs.push('-p');
-                cleanArgs.push('android');
             }
-
+            
+            cleanArgs.push('clean');
+            cleanArgs.push('-p');
+            cleanArgs.push('android');
+            
             exec(cfg.cli, cleanArgs, null, function(e){
                 console.log(chalk.cyan('Starting Appcelerator Build'));
                 console.log("\n");
 
-                var buildArgs = [];
-
-                if(cfg.cli == "appc"){
-                    buildArgs.push('run');
-                    buildArgs.push('-p');
-                    buildArgs.push('android');
-                    buildArgs.push('--build-only');
-                }else{
-                    buildArgs.push('build');
-                    buildArgs.push('-p');
-                    buildArgs.push('android');
-                    buildArgs.push('--build-only');
-                }
+                var buildArgs = [cfg.cli == "appc"?'run':'build'];
+                var buildArgsDetail = '-p android --build-only';
+                buildArgs = buildArgs.concat(buildArgsDetail.split(' '));
 
                 exec(cfg.cli, buildArgs, null, function(e){
                     _supply(1);

--- a/index.js
+++ b/index.js
@@ -210,11 +210,19 @@ function uploadBetaTestIPA(_skip){
         console.log(chalk.yellow('First things first. Clean project to ensure build'));
         console.log("\n");
 
-        var cleanArgs = [
-            'ti',
-            'clean',
-            '-p', 'ios'
-        ];
+        var cleanArgs = [];
+        
+        if(cfg.cli == "appc"){
+            cleanArgs.push('ti');
+            cleanArgs.push('clean');
+            cleanArgs.push('-p');
+            cleanArgs.push('ios');
+
+        }else{
+            cleanArgs.push('clean');
+            cleanArgs.push('-p');
+            cleanArgs.push('ios');
+        }
 
         exec(cfg.cli, cleanArgs, null, function(e){
             console.log(chalk.cyan('Starting Appcelerator App Store Build'));
@@ -227,13 +235,27 @@ function uploadBetaTestIPA(_skip){
             if(fs.existsSync("./dist/" + tiapp.name + ".ipa")){
                 fs.unlinkSync("./dist/" + tiapp.name + ".ipa");
             }
+            
+            var buildArgs = [];
 
-            var buildArgs = [
-                'run',
-                '-p', 'ios',
-                '-T', 'dist-adhoc',
-                '-O', './dist'
-            ];
+            if(cfg.cli == "appc"){
+                buildArgs.push('run');
+                buildArgs.push('-p');
+                buildArgs.push('ios');
+                buildArgs.push('-T');
+                buildArgs.push('dist-adhoc');
+                buildArgs.push('-O');
+                buildArgs.push('./dist');
+            }else{
+                buildArgs.push('build');
+                buildArgs.push('-p');
+                buildArgs.push('ios');
+                buildArgs.push('-T');
+                buildArgs.push('dist-adhoc');
+                buildArgs.push('-O');
+                buildArgs.push('./dist');
+            }
+            
 
             exec(cfg.cli, buildArgs, null, function(e){
                 _pilot();

--- a/index.js
+++ b/index.js
@@ -895,6 +895,16 @@ exports.pilot = function(opts){
     pilotArgs.push(cfg.apple_id);
     pilotArgs.push('-a');
     pilotArgs.push(tiapp.id);
+    
+    if(cfg.team_name){
+      pilotArgs.push('-r');
+      pilotArgs.push(cfg.team_name);
+    }
+    
+    if(cfg.team_id){
+      pilotArgs.push('-q');
+      pilotArgs.push(cfg.team_id);
+    }
 
     exec('pilot', pilotArgs, null, function(e){
         console.log(chalk.cyan('\nPilot ' + opts.command + ' completed\n'));


### PR DESCRIPTION
I fixed two issue.
- after setup to use `ti` cli, `tifast send -t` doesn't work with error. : cfg.cli checking is required everywhere.
- Add team name and team id args to pilotArgs
