### PR TITLE
Fastlane 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Building apps for iOS and Android it's all great until you have to deal with Cer
 TiFastlane is a way to use those tools for Titanium development. Now you'll be able to do real continous deployment of your Titanium app. Sending your app for review will be a breeze:
 
 	tifast send
-	
+
 And publishing your new version to the Play Store will be as easy:
 
 	tifast playsend
@@ -48,6 +48,7 @@ With TiFastlane you'll be able to fully optimize the way you submit your app upd
 * [Jason Kneen](https://github.com/jasonkneen) for creating some awesome CLI tools from which I'm basing this one
 
 ## Changelog
+* 0.8.0 BC BREAK to support Fastlane 2.
 * 0.7.0 Bug fixes. Added new `repairprofiles` and `downloadprofiles`
 * 0.6.0 `playsend` now uses a JSON key instead of a P12 key. This is a breaking change and the setup needs to be done again.
 * 0.5.1 Removed automatic Fastlane installation, updated Install Guide.

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ exports.loadconfig = function( cfg_file ){
       , appDeliveryMetaDir = (!cfg.locale) ? appDeliveryDir + '/metadata/en-US' : appDeliveryDir + '/metadata/' + cfg.locale
       , appDeliveryScreenDir = (!cfg.locale) ? appDeliveryDir + '/screenshots/en-US' : appDeliveryDir + '/screenshots/' + cfg.locale
       , fastlaneBinary = (cfg.fastlane_binary)
-      		? (path.isAbsolute(cfg.fastlane_binary)
+      		? (path.isAbsolute(cfg.fastlane_binary) || cfg.fastlane_binary === 'fastlane'
       			? cfg.fastlane_binary
       			: fs.realpathSync(path.dirname(cfgfile) + "/" + cfg.fastlane_binary))
       		: 'fastlane'

--- a/index.js
+++ b/index.js
@@ -158,9 +158,11 @@ function uploadMetadata(){
         return;
     }
 
-    var initArgs = [];
+    var initArgs = [
+        'deliver'
+    ];
 
-    exec('deliver', initArgs, { cwd: appDeliveryDir }, function(e){
+    exec('fastlane', initArgs, { cwd: appDeliveryDir }, function(e){
         console.log(chalk.green('\nDone\n'));
     });
 };
@@ -183,6 +185,7 @@ function uploadBetaTestIPA(opts){
         console.log(chalk.yellow('Starting Pilot'));
 
         var pilotArgs = [
+            'pilot',
             'upload'
           , '-u' , cfg.apple_id
           , '-i' , "../../dist/" + tiapp.name + ".ipa"
@@ -194,7 +197,7 @@ function uploadBetaTestIPA(opts){
             );
         }
 
-        exec('pilot', pilotArgs, { cwd: appDeliveryDir }, function(e){
+        exec('fastlane', pilotArgs, { cwd: appDeliveryDir }, function(e){
             console.log(chalk.green('\nDone\n'));
         });
     };
@@ -273,12 +276,13 @@ function smartInit(){
     }
 
     var initArgs = [
+        'deliver',
         'init',
         '--username', cfg.apple_id,
         '-a', tiapp.id
     ];
 
-    exec('deliver', initArgs, { cwd: appDeliveryDir }, function(e){
+    exec('fastlane', initArgs, { cwd: appDeliveryDir }, function(e){
         // Create Extra Files
         extraFiles();
 
@@ -506,7 +510,9 @@ exports.send = function(opts){
         console.log("\n");
         console.log(chalk.yellow('Starting Deliver'));
 
-        var initArgs = [];
+        var initArgs = [
+            'deliver'
+        ];
 
         if( sendipa ){
             initArgs.push('-i', '../../dist/' + tiapp.name + '.ipa');
@@ -534,7 +540,7 @@ exports.send = function(opts){
         }
 
 
-        exec('deliver', initArgs, { cwd: appDeliveryDir }, function(e){
+        exec('fastlane', initArgs, { cwd: appDeliveryDir }, function(e){
             console.log(chalk.green('\nDeliver Done\n'));
         });
 
@@ -662,6 +668,7 @@ exports.register = function(opts){
     console.log( chalk.white('Version: ' + tiapp.version) );
 
     var produceArgs = [
+        'produce',
         '--username', cfg.apple_id,
         '--app_identifier', tiapp.id,
         '--app_version', tiapp.version,
@@ -682,7 +689,7 @@ exports.register = function(opts){
         produceArgs.push('--skip_itc');
     }
 
-    exec('produce', produceArgs, null,
+    exec('fastlane', produceArgs, null,
         function(e) {
 
             //We have the app created, now let's build the provisioning profiles with fastlane.sigh
@@ -708,6 +715,7 @@ exports.register = function(opts){
                 console.log( chalk.cyan('Creating Provision Profile on environment: ' + p) );
 
                 var sighArgs = [
+                    'sigh',
                     '-u', cfg.apple_id,
                     '-a', tiapp.id,
                     '-o', certDir
@@ -738,7 +746,7 @@ exports.register = function(opts){
                     sighArgs.push('--adhoc');
                 }
 
-                exec('sigh', sighArgs, null,
+                exec('fastlane', sighArgs, null,
                     function(e) {
                         //Done
                     }
@@ -767,6 +775,7 @@ exports.repairprofiles = function(opts){
     console.log( chalk.cyan('Repairing all provisioning profiles on account') );
 
     var sighArgs = [
+        'sigh',
         'repair',
         '--username', cfg.apple_id,
         '--app_identifier', tiapp.id
@@ -782,7 +791,7 @@ exports.repairprofiles = function(opts){
         sighArgs.push(cfg.team_name);
     }
 
-    exec('sigh', sighArgs, null,
+    exec('fastlane', sighArgs, null,
         function(e) {
             //Done
         }
@@ -807,6 +816,7 @@ exports.downloadprofiles = function(opts){
     console.log( chalk.cyan('Downloading all provisioning profiles on account') );
 
     var sighArgs = [
+        'sigh',
         'download_all',
         '--username', cfg.apple_id,
         '--app_identifier', tiapp.id
@@ -822,7 +832,7 @@ exports.downloadprofiles = function(opts){
         sighArgs.push(cfg.team_name);
     }
 
-    exec('sigh', sighArgs, null,
+    exec('fastlane', sighArgs, null,
         function(e) {
             //Done
         }
@@ -878,6 +888,7 @@ exports.pem = function(opts){
     }
 
     var pemArgs = [
+        'pem',
         '-l', certDir,
         '-a', tiapp.id,
         '-u', cfg.apple_id
@@ -898,7 +909,7 @@ exports.pem = function(opts){
 
     console.log( chalk.cyan('Starting Pem'));
 
-    exec('pem', pemArgs,null, function(e){
+    exec('fastlane', pemArgs,null, function(e){
         console.log(chalk.green('\nPem Done\n'));
     });
 };
@@ -924,7 +935,9 @@ exports.pilot = function(opts){
     console.log( chalk.cyan('Starting Pilot ' + opts.command));
     console.log('\n');
 
-    var pilotArgs = [];
+    var pilotArgs = [
+        'pilot'
+    ];
 
     switch(opts.command){
         case "add":
@@ -983,18 +996,18 @@ exports.pilot = function(opts){
     pilotArgs.push(cfg.apple_id);
     pilotArgs.push('-a');
     pilotArgs.push(tiapp.id);
-    
+
     if(cfg.team_name){
       pilotArgs.push('-r');
       pilotArgs.push(cfg.team_name);
     }
-    
+
     if(cfg.team_id){
       pilotArgs.push('-q');
       pilotArgs.push(cfg.team_id);
     }
 
-    exec('pilot', pilotArgs, null, function(e){
+    exec('fastlane', pilotArgs, null, function(e){
         console.log(chalk.cyan('\nPilot ' + opts.command + ' completed\n'));
     });
 };
@@ -1031,12 +1044,13 @@ exports.playinit = function(opts){
     }
     
     var initArgs = [
+        'supply',
         'init',
         '--json_key', "../../../" + cfg.google_play_json_key,
         '--package_name', tiapp.id
     ];
 
-    exec('supply', initArgs, { cwd: appAndroidDeliveryDir }, function(e){
+    exec('fastlane', initArgs, { cwd: appAndroidDeliveryDir }, function(e){
         console.log(chalk.green('Your app has been initialized.'));
         console.log(chalk.green('You can find your configuration files for delivery on: ' + appAndroidDeliveryDir));
         console.log(chalk.green('Now the fun starts!'));
@@ -1083,6 +1097,7 @@ exports.playsend = function(opts){
         console.log(chalk.yellow('Starting Supply'));
 
         var initArgs = [
+            'supply',
             '--json_key', "../../../" + cfg.google_play_json_key,
             '--package_name', tiapp.id
         ];
@@ -1136,7 +1151,7 @@ exports.playsend = function(opts){
             );
         }
 
-        exec('supply', initArgs, { cwd: appAndroidDeliveryDir }, function(e){
+        exec('fastlane', initArgs, { cwd: appAndroidDeliveryDir }, function(e){
             console.log(chalk.green('\nSupply Done\n'));
         });
     }

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function uploadMetadata(){
 @ upload Beta Test IPA
 */
 function uploadBetaTestIPA(opts){
-    
+
     if (!fs.existsSync(appDeliveryDir + "/Deliverfile")){
         console.log(chalk.red('You need to run "tifast init" first'));
         return;
@@ -227,11 +227,11 @@ function uploadBetaTestIPA(opts){
         if(cfg.cli == "appc"){
             cleanArgs.push('ti');
         }
-        
+
         cleanArgs.push('clean');
         cleanArgs.push('-p');
         cleanArgs.push('ios');
-        
+
 
         exec(cfg.cli, cleanArgs, null, function(e){
             console.log(chalk.cyan('Starting Appcelerator App Store Build'));
@@ -244,11 +244,11 @@ function uploadBetaTestIPA(opts){
             if(fs.existsSync("./dist/" + tiapp.name + ".ipa")){
                 fs.unlinkSync("./dist/" + tiapp.name + ".ipa");
             }
-            
+
             var buildArgs = [cfg.cli == "appc"?'run':'build'];
             var buildArgsDetail = '-p ios -T dist-adhoc -O ./dist';
             buildArgs = buildArgs.concat(buildArgsDetail.split(' '));
-            
+
             exec(cfg.cli, buildArgs, null, function(e){
                 _pilot();
             });
@@ -590,7 +590,7 @@ exports.send = function(opts){
             if(cfg.cli == "appc"){
                 cleanArgs.push('ti');
             }
-            
+
             cleanArgs.push('clean');
 
             exec(cfg.cli, cleanArgs, null, function(e){
@@ -770,7 +770,7 @@ exports.repairprofiles = function(opts){
         console.log('\n ');
         return
     }
-    
+
     //First step is to register the application using fastlane.produce
     console.log( chalk.cyan('Repairing all provisioning profiles on account') );
 
@@ -811,7 +811,7 @@ exports.downloadprofiles = function(opts){
         console.log('\n ');
         return
     }
-    
+
     //First step is to register the application using fastlane.produce
     console.log( chalk.cyan('Downloading all provisioning profiles on account') );
 
@@ -1042,7 +1042,7 @@ exports.playinit = function(opts){
     if (!fs.existsSync(appAndroidDeliveryDir)){
         fs.mkdirSync(appAndroidDeliveryDir);
     }
-    
+
     var initArgs = [
         'supply',
         'init',
@@ -1062,7 +1062,7 @@ exports.playinit = function(opts){
 @ export playsend function to CLI
 */
 exports.playsend = function(opts){
-    
+
     if(!fs.existsSync(cfgfile)){
         console.log(chalk.red("==================================="));
         console.log(chalk.red('Cannot find ', cfgfile));
@@ -1123,7 +1123,7 @@ exports.playsend = function(opts){
         else{
             initArgs.push(
                 '--skip_upload_apk'
-            );            
+            );
         }
 
         if( opts.skip_upload_graphic_assets ){
@@ -1184,9 +1184,9 @@ exports.playsend = function(opts){
             if(cfg.cli == "appc"){
                 cleanArgs.push('ti');
             }
-            
+
             cleanArgs.push('clean');
-            
+
             exec(cfg.cli, cleanArgs, null, function(e){
                 console.log(chalk.cyan('Starting Appcelerator Build'));
                 console.log("\n");

--- a/index.js
+++ b/index.js
@@ -904,7 +904,7 @@ exports.pem = function(opts){
 
     var pemArgs = [
         'pem',
-        '-l', certDir,
+        '-e', certDir,
         '-a', tiapp.id,
         '-u', cfg.apple_id
     ];
@@ -916,7 +916,7 @@ exports.pem = function(opts){
 
     if(opts.development) pemArgs.push('--development');
 
-    if(opts.generate_p12) pemArgs.push('-g');
+    if(opts.generate_p12) pemArgs.push('--generate_p12');
 
     if(opts.save_private_key) pemArgs.push('-s');
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -11,11 +11,12 @@ exports.cfgFile = "{\n" +
 " , \"locale\": \"[LOCALE]\" \n" +
 " , \"apple_id\": \"[APPLE_ID]\" \n" +
 " , \"team_id\": \"[TEAM_ID]\" \n" +
-" , \"team_name\": \"[TEAM_NAME]\" \n" + 
-" , \"google_play_json_key\": \"[GOOGLE_PLAY_JSON_KEY]\" \n" + 
-" , \"google_keystore_file\": \"[GOOGLE_KEYSTORE_FILE]\" \n" + 
-" , \"google_keystore_password\": \"[GOOGLE_KEYSTORE_PASSWORD]\" \n" + 
-" , \"google_keystore_alias\": \"[GOOGLE_KEYSTORE_ALIAS]\" \n" + 
+" , \"team_name\": \"[TEAM_NAME]\" \n" +
+" , \"google_play_json_key\": \"[GOOGLE_PLAY_JSON_KEY]\" \n" +
+" , \"google_keystore_file\": \"[GOOGLE_KEYSTORE_FILE]\" \n" +
+" , \"google_keystore_password\": \"[GOOGLE_KEYSTORE_PASSWORD]\" \n" +
+" , \"google_keystore_alias\": \"[GOOGLE_KEYSTORE_ALIAS]\" \n" +
+" , \"fastlane_binary\": \"[FASTLANE_BINARY]\" \n" +
 "}";
 
 /*

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   ],
   "_from": "tifastlane@*",
-  "_id": "tifastlane@0.7.0",
+  "_id": "tifastlane@0.8.0",
   "_inCache": true,
   "_installable": true,
   "_location": "/tifastlane",
@@ -90,7 +90,7 @@
     "url": "git+https://github.com/ulizama/TiFastlane.git"
   },
   "scripts": {
-    
+
   },
-  "version": "0.7.0"
+  "version": "0.8.0"
 }


### PR DESCRIPTION
### What

Fastlane.tools changed the CLI commands into actions of one binary `fastlane`. All commands have become the first parameter to be executed.
This PR introduces that change, resulting in dropping support for Fastlane 1.

### How to test

1. Install fastlane 2 globally and see that `tifastlane` works
1. Install fastlane 2 locally, update `tifastlane.cfg` with relative path to `fastlane_binary` and see that `tifastlane` works 

### Notes

https://github.com/fastlane/fastlane/releases/tag/2.0.0