### PR TITLE
Fix missing team support on Pem action

### DIFF
--- a/index.js
+++ b/index.js
@@ -926,6 +926,16 @@ exports.pem = function(opts){
         '-u', cfg.apple_id
     ];
 
+    if( cfg.team_id != "null" ){
+        pemArgs.push('--team_id');
+        pemArgs.push(cfg.team_id);
+    }
+
+    if( cfg.team_name != "null" ){
+        pemArgs.push('--team_name');
+        pemArgs.push(cfg.team_name);
+    }
+
     if(opts.password != null){
         pemArgs.push('-p');
         pemArgs.push(opts.password);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   ],
   "_from": "tifastlane@*",
-  "_id": "tifastlane@0.8.0",
+  "_id": "tifastlane@0.8.1",
   "_inCache": true,
   "_installable": true,
   "_location": "/tifastlane",
@@ -92,5 +92,5 @@
   "scripts": {
 
   },
-  "version": "0.8.0"
+  "version": "0.8.1"
 }


### PR DESCRIPTION
### What

The PEM action was missing the additional team checks. This PR fixes this shortcoming.

### How to test

1. Use a developer account that has multiple teams
1. Run `tifast pem -g -s -c tifastlane.cfg` and see that it won't ask to select a team ID anymore.