### PR TITLE
`apple_watch_app_icon` error on deliver

### DIFF
--- a/index.js
+++ b/index.js
@@ -646,7 +646,7 @@ exports.send = function(opts){
         }
 
         if(cfg.team_id != "null"){
-          initArgs.push('-q');
+          initArgs.push('-k');
           initArgs.push(cfg.team_id);
         }
 

--- a/index.js
+++ b/index.js
@@ -645,11 +645,6 @@ exports.send = function(opts){
           initArgs.push(cfg.team_name);
         }
 
-        if(cfg.team_id != "null"){
-          initArgs.push('-k');
-          initArgs.push(cfg.team_id);
-        }
-
         exec(fastlaneBinary, initArgs, { cwd: appDeliveryDir }, function(e){
             console.log(chalk.green('\nDeliver Done\n'));
         });

--- a/index.js
+++ b/index.js
@@ -641,7 +641,7 @@ exports.send = function(opts){
         }
         
         if(cfg.team_name != "null"){
-          initArgs.push('-r');
+          initArgs.push('-e');
           initArgs.push(cfg.team_name);
         }
 


### PR DESCRIPTION
https://github.com/fastlane/fastlane/blob/75ad110f9661a444b3a7c85723e6d273877ace15/deliver/lib/deliver/options.rb#L221

Some deliver parameter options are incorrect.
It's crtitical bug on TiFastlane.

`-q` option is key of `apple_watch_app_icon` on deliver, `-k` is correct for `team_id`.
But string type `team_id` is incorrect. deliver want to integer type team_id.

and `-r` option is key of `price_tier` on deliver, `-e` is correct for `team_name`.

If only provide `team_name` then, deliver process success.
It dosen't need `team_id` option.