### PR TITLE
feat: add Android App Bundle (.aab) support and more

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -168,6 +168,7 @@ program.command('playsend')
     .option('--bump_build_version', 'Automatically bump Android build version')
     .option('-a, --track [value]', 'The Track to upload the Application to: production, beta, alpha or rollout')
     .option('-r, --rollout [value]', 'The percentage of the rollout')
+    .option('--aab', 'Send the AAB instead of the APK')
     .action(playsend)
     ;
 

--- a/cli.js
+++ b/cli.js
@@ -169,6 +169,7 @@ program.command('playsend')
     .option('-a, --track [value]', 'The Track to upload the Application to: production, beta, alpha or rollout')
     .option('-r, --rollout [value]', 'The percentage of the rollout')
     .option('--aab', 'Send the AAB instead of the APK')
+    .option('--validate_only', 'Whether to upload and validate but not publish immediately')
     .action(playsend)
     ;
 

--- a/index.js
+++ b/index.js
@@ -1365,6 +1365,12 @@ exports.playsend = function(opts){
             );
         }
 
+        if( opts.validate_only ){
+            initArgs.push(
+                '--validate_only'
+            );
+        }
+
         if( opts.skip_upload_screenshots ){
             initArgs.push(
                 '--skip_upload_screenshots'

--- a/index.js
+++ b/index.js
@@ -1336,9 +1336,15 @@ exports.playsend = function(opts){
                 );
             }
 
-            initArgs.push(
-                '--apk', '../../../dist/' + tiapp.name + '.apk'
-            );
+            if( opts.aab) {
+                initArgs.push(
+                    '--aab', '../../../dist/' + tiapp.name + '.aab'
+                );
+            } else {
+                initArgs.push(
+                    '--apk', '../../../dist/' + tiapp.name + '.apk'
+                );
+            }
         }
         else{
             initArgs.push(

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "url": "git+https://github.com/ulizama/TiFastlane.git"
   },
   "scripts": {},
-  "version": "0.10.8"
+  "version": "0.11.0"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "inquirer": "^3.3.0",
     "path": "^0.12.7",
     "pinkie-promise": "^2.0.1",
-    "plist": "^2.0.1",
     "sudo": "^1.0.3",
     "tiapp.xml": "^0.2.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
- Ti SDK 9+ supports Gradle, Android X, Jetpack and: App bundles! TiFastlane now does as well :)
- Support for the `--validate_only` flag so the binary is uploaded and validated, but not published immediately.